### PR TITLE
Handle states without successors

### DIFF
--- a/salty/Main.hs
+++ b/salty/Main.hs
@@ -51,6 +51,9 @@ main  =
 
      (fsm, cont) <- genFSM opts input
 
+     unless (and (checkHasSuccessors fsm)) $
+       putStrLn "Warning: there exist states with no successors"
+
      case optJava opts of
        Just pkg -> writePackage opts (javaFSM pkg fsm)
        Nothing  -> return ()
@@ -160,6 +163,10 @@ genFSM opts (InpSlugsOut path) =
        Just fsm -> return (fsm,Nothing)
        Nothing  -> do putStrLn "Failed to parse slugs output"
                       exitFailure
+
+checkHasSuccessors :: FSM -> [Bool]
+checkHasSuccessors FSM { fsmNodes } =
+  [ not (null nodeTrans) | (_, Node { nodeTrans }) <- Map.toList fsmNodes ]
 
 -- | Used to dump messages and AST to stderr.
 output :: Doc -> IO ()

--- a/salty/Main.hs
+++ b/salty/Main.hs
@@ -166,7 +166,7 @@ genFSM opts (InpSlugsOut path) =
 
 checkHasSuccessors :: FSM -> [Bool]
 checkHasSuccessors FSM { fsmNodes } =
-  [ not (null nodeTrans) | (_, Node { nodeTrans }) <- Map.toList fsmNodes ]
+  map (not . null . nodeTrans) (Map.elems fsmNodes)
 
 -- | Used to dump messages and AST to stderr.
 output :: Doc -> IO ()

--- a/src/CodeGen/SPARK.hs
+++ b/src/CodeGen/SPARK.hs
@@ -418,7 +418,11 @@ mkNested :: Map.Map Int Node -> Doc -> Doc -> SpecVar -> SpecVar -> Doc
 mkNested ns cntlrName stName env sys =
   vcat [ text "case" <+> qualify (Just cntlrName) stName <+> text "is"
        , indent 2 $ vcat [ vcat [ text "when" <+> pp (s+1) <+> text "=>"
-                                , indent 2 $ mkNested' ns cntlrName stName env sys (sort nodeTrans) [] False PP.empty ]
+                                , indent 2 $
+                                    case nodeTrans of
+                                      [] -> statement $ text "raise Program_Error"
+                                      _  -> mkNested' ns cntlrName stName env sys (sort nodeTrans) [] False PP.empty
+                                ]
                            | (s, Node { nodeTrans }) <- Map.toList ns ]
        , statement $ text "end case" ]
   where


### PR DESCRIPTION
A warning is unconditionally issued after the FSM is created if there exist any states without successors.  For the SPARK codegen target, raise an exception in Move for those states.